### PR TITLE
fix(webapck.config): Fix and set the open page as the "/#/mind" page

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A visual graph editor based on G6 and React",
   "main": "dist/bundle.js",
   "scripts": {
-    "start": "webpack-dev-server --config ./tools/webpack.config.demo.dev.js --open",
+    "start": "webpack-dev-server --config ./tools/webpack.config.demo.dev.js",
     "watch": "node --max_old_space_size=8192 ./node_modules/webpack/bin/webpack --config ./tools/webpack.config.dev.js --watch",
     "build": "NODE_ENV=production node --max_old_space_size=8192 ./node_modules/webpack/bin/webpack --config ./tools/webpack.config.prod.js --colors --profile --optimize-minimize",
     "build:demo": "NODE_ENV=production node --max_old_space_size=8192 ./node_modules/webpack/bin/webpack --config ./tools/webpack.config.demo.prod.js --colors --profile --optimize-minimize"

--- a/tools/webpack.config.demo.dev.js
+++ b/tools/webpack.config.demo.dev.js
@@ -37,6 +37,8 @@ const devServer = {
   contentBase: path.resolve(__dirname, '..', 'demo'),
   publicPath: '/dist',
   disableHostCheck: true,
+  open: true,
+  openPage: '/#/mind',
 };
 
 const output = {


### PR DESCRIPTION
Now when running `npm start`,  it opens the page `/#/` which is an empty page and it is confusing to many developers. 

This PR is to set the open page to `/#/mind` which shows the mind graph.

related: https://github.com/gaoli/GGEditor/issues/58