### PR TITLE
docs: 修改自定义节点链接

### DIFF
--- a/docs/api/registerNode.en-US.md
+++ b/docs/api/registerNode.en-US.md
@@ -4,7 +4,7 @@ To register a node.
 
 ## Usage
 
-> G6 [Custom Shape (Chinese)](https://antv.alipay.com/zh-cn/g6/1.x/tutorial/custom-shape.html) Tutorial
+> G6 [Custom Shape (Chinese)](https://www.yuque.com/antv/g6/custom-node) Tutorial
 
 ```jsx
 import GGEditor, { Flow, RegisterNode } from 'gg-editor';
@@ -17,17 +17,17 @@ import GGEditor, { Flow, RegisterNode } from 'gg-editor';
 
 ## API
 
-| Property | Description | Type | Default |
-| :--- | :--- | :--- | :--- |
-| name | The name of a node. | `string` | - |
-| config | To configurate a node. | `object` | - |
-| extend | To extend a shape. | `string` | - |
+| Property | Description            | Type     | Default |
+| :------- | :--------------------- | :------- | :------ |
+| name     | The name of a node.    | `string` | -       |
+| config   | To configurate a node. | `object` | -       |
+| extend   | To extend a shape.     | `string` | -       |
 
 ## Built-in Nodes
 
-| Node Name | Preview | Applicable Page |
-| :--- | :--- | :--- |
-| flow-circle | ![Cicle Nodes Figure](https://gw.alipayobjects.com/zos/rmsportal/ZnPxbVjKYADMYxkTQXRi.svg) | Flow |
-| flow-rect | ![Rect Node Figure](https://gw.alipayobjects.com/zos/rmsportal/wHcJakkCXDrUUlNkNzSy.svg) | Flow |
-| flow-rhombus | ![Rhombus Node Figure](https://gw.alipayobjects.com/zos/rmsportal/SnWIktArriZRWdGCnGfK.svg) | Flow |
-| flow-capsule | ![Capsule Node Figure](https://gw.alipayobjects.com/zos/rmsportal/rQMUhHHSqwYsPwjXxcfP.svg) | Flow |
+| Node Name    | Preview                                                                                     | Applicable Page |
+| :----------- | :------------------------------------------------------------------------------------------ | :-------------- |
+| flow-circle  | ![Cicle Nodes Figure](https://gw.alipayobjects.com/zos/rmsportal/ZnPxbVjKYADMYxkTQXRi.svg)  | Flow            |
+| flow-rect    | ![Rect Node Figure](https://gw.alipayobjects.com/zos/rmsportal/wHcJakkCXDrUUlNkNzSy.svg)    | Flow            |
+| flow-rhombus | ![Rhombus Node Figure](https://gw.alipayobjects.com/zos/rmsportal/SnWIktArriZRWdGCnGfK.svg) | Flow            |
+| flow-capsule | ![Capsule Node Figure](https://gw.alipayobjects.com/zos/rmsportal/rQMUhHHSqwYsPwjXxcfP.svg) | Flow            |

--- a/docs/api/registerNode.zh-CN.md
+++ b/docs/api/registerNode.zh-CN.md
@@ -4,7 +4,7 @@
 
 ## 使用说明
 
-> G6 [自定义图项](https://antv.alipay.com/zh-cn/g6/1.x/tutorial/custom-shape.html) 教程
+> G6 [自定义图项](https://www.yuque.com/antv/g6/custom-node) 教程
 
 ```jsx
 import GGEditor, { Flow, RegisterNode } from 'gg-editor';
@@ -17,17 +17,17 @@ import GGEditor, { Flow, RegisterNode } from 'gg-editor';
 
 ## API
 
-| 属性 | 说明 | 类型 | 默认值 |
-| :--- | :--- | :--- | :--- |
-| name | 节点名称 | `string` | - |
-| config | 节点配置 | `object` | - |
-| extend | 继承图形 | `string` | - |
+| 属性   | 说明     | 类型     | 默认值 |
+| :----- | :------- | :------- | :----- |
+| name   | 节点名称 | `string` | -      |
+| config | 节点配置 | `object` | -      |
+| extend | 继承图形 | `string` | -      |
 
 ## 内置节点
 
-| 节点英文名 | 节点中文名 | 示例预览 |适用页面 |
-| :--- | :--- | :--- | :--- |
-| flow-circle | 起止节点 | ![起止节点](https://gw.alipayobjects.com/zos/rmsportal/ZnPxbVjKYADMYxkTQXRi.svg) | Flow |
-| flow-rect | 常规节点 | ![起止节点](https://gw.alipayobjects.com/zos/rmsportal/wHcJakkCXDrUUlNkNzSy.svg) | Flow |
-| flow-rhombus | 分叉节点 | ![分叉节点](https://gw.alipayobjects.com/zos/rmsportal/SnWIktArriZRWdGCnGfK.svg) | Flow |
-| flow-capsule | 模型节点 | ![模型节点](https://gw.alipayobjects.com/zos/rmsportal/rQMUhHHSqwYsPwjXxcfP.svg) | Flow |
+| 节点英文名   | 节点中文名 | 示例预览                                                                         | 适用页面 |
+| :----------- | :--------- | :------------------------------------------------------------------------------- | :------- |
+| flow-circle  | 起止节点   | ![起止节点](https://gw.alipayobjects.com/zos/rmsportal/ZnPxbVjKYADMYxkTQXRi.svg) | Flow     |
+| flow-rect    | 常规节点   | ![起止节点](https://gw.alipayobjects.com/zos/rmsportal/wHcJakkCXDrUUlNkNzSy.svg) | Flow     |
+| flow-rhombus | 分叉节点   | ![分叉节点](https://gw.alipayobjects.com/zos/rmsportal/SnWIktArriZRWdGCnGfK.svg) | Flow     |
+| flow-capsule | 模型节点   | ![模型节点](https://gw.alipayobjects.com/zos/rmsportal/rQMUhHHSqwYsPwjXxcfP.svg) | Flow     |


### PR DESCRIPTION
G6文档好像迁移到语雀上了，以前的链接被重定向到AntV首页。

